### PR TITLE
WIP run pytest through docker

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+######################################################################
+# PY stage that simply does a pip install on our requirements
+######################################################################
+ARG PY_VER=3.7.9
+FROM python:${PY_VER} AS superset-py
+
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    FLASK_ENV=production \
+    FLASK_APP="superset.app:create_app()" \
+    PYTHONPATH="/app/pythonpath" \
+    SUPERSET_HOME="/app/superset_home" \
+    SUPERSET_PORT=8088
+
+RUN mkdir -p ${SUPERSET_HOME} ${PYTHONPATH} \
+        && apt-get update -y \
+        && apt-get install -y --no-install-recommends \
+            build-essential \
+            default-libmysqlclient-dev \
+            libpq-dev \
+            libsasl2-dev \
+            libecpg-dev \
+            libsasl2-modules-gssapi-mit \
+        && rm -rf /var/lib/apt/lists/*
+
+COPY ./requirements/*.txt  /app/requirements/
+COPY setup.py MANIFEST.in README.md /app/
+COPY superset-frontend/package.json /app/superset-frontend/
+RUN cd /app \
+    && mkdir -p superset/static \
+    && touch superset/static/version_info.json \
+    && pip install --no-cache -r requirements/local.txt \
+    && pip install --no-cache -r requirements/testing.txt
+
+RUN mv /usr/local/bin/gunicorn /usr/bin/
+RUN mv /usr/local/bin/celery /usr/bin
+RUN mv /usr/local/bin/flask /usr/bin
+RUN mv /usr/local/bin/pytest /usr/bin
+
+COPY superset /app/superset
+COPY setup.py MANIFEST.in README.md /app/
+
+COPY tests /app/tests
+COPY pytest.ini /app
+
+RUN cd /app && pip install -e .
+
+COPY ./docker/*.sh /app/docker/
+
+WORKDIR /app
+
+RUN superset db upgrade
+RUN superset init
+
+# Override this in docker-compose file
+ENTRYPOINT [ "/app/docker/docker-run-tests.sh" ]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -41,6 +41,8 @@ RUN mkdir -p ${SUPERSET_HOME} ${PYTHONPATH} \
         && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements/*.txt  /app/requirements/
+COPY setup.py MANIFEST.in README.md /app/
+COPY superset-frontend/package.json /app/superset-frontend/
 RUN cd /app \
     && mkdir -p superset/static \
     && touch superset/static/version_info.json \
@@ -53,7 +55,6 @@ RUN mv /usr/local/bin/flask /usr/bin
 RUN mv /usr/local/bin/pytest /usr/bin
 
 COPY superset /app/superset
-COPY setup.py MANIFEST.in README.md /app/
 
 COPY tests /app/tests
 COPY pytest.ini /app

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -41,8 +41,6 @@ RUN mkdir -p ${SUPERSET_HOME} ${PYTHONPATH} \
         && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements/*.txt  /app/requirements/
-COPY setup.py MANIFEST.in README.md /app/
-COPY superset-frontend/package.json /app/superset-frontend/
 RUN cd /app \
     && mkdir -p superset/static \
     && touch superset/static/version_info.json \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -65,8 +65,5 @@ COPY ./docker/*.sh /app/docker/
 
 WORKDIR /app
 
-RUN superset db upgrade
-RUN superset init
-
 # Override this in docker-compose file
 ENTRYPOINT [ "/app/docker/docker-run-tests.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -75,5 +75,9 @@ py-format: pre-commit
 js-format:
 	cd superset-frontend; npm run prettier
 
+create-test-db:
+	docker-compose -f docker-compose.test.yml up -d postgres
+	docker-compose -f docker-compose.test.yml run postgres "(psql -U superset -d postgres -tc \"SELECT count(*) FROM pg_database WHERE datname = 'test'\" | grep -q 0) && psql -U superset -d postgres -c 'CREATE DATABASE test'"
+
 pytest:
 	docker-compose -f docker-compose.test.yml run superset-tests-with-postgres

--- a/Makefile
+++ b/Makefile
@@ -74,3 +74,6 @@ py-format: pre-commit
 
 js-format:
 	cd superset-frontend; npm run prettier
+
+pytest:
+	docker-compose -f docker-compose.test.yml run superset-tests-with-postgres

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -60,7 +60,6 @@ services:
     image: superset-tests-image
     container_name: superset_test_worker
     command: ["celery", "worker", "--app=superset.tasks.celery_app:app", "-Ofair", "-c", "2"]
-    restart: unless-stopped
     networks:
       - test-network
     user: "root"
@@ -81,7 +80,6 @@ services:
     image: superset-tests-image
     container_name: superset_test_app
     command: ["pytest", "tests"]
-    restart: unless-stopped
     networks:
       - test-network
     user: "root"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -48,7 +48,7 @@ services:
     expose:
       - "5432"
     volumes:
-      - db_home:/var/lib/postgresql/data
+      - test_db_home:/var/lib/postgresql/data
 
   superset-tests-base:
     build:
@@ -100,7 +100,7 @@ services:
 volumes:
   superset_home:
     external: false
-  db_home:
+  test_db_home:
     external: false
   redis:
     external: false

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,108 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+x-superset-volumes: &superset-volumes
+  # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
+  - ./docker:/app/docker
+  - ./superset:/app/superset
+  - superset_home:/app/superset_home
+  - ./tests:/app/tests
+
+networks:
+  test-network:
+    driver: bridge
+
+version: "3.7"
+services:
+  redis:
+    image: redis:latest
+    container_name: superset_test_redis
+    restart: unless-stopped
+    networks:
+      - test-network
+    expose:
+      - "6379"
+    volumes:
+      - redis:/data
+
+  postgres:
+    env_file: docker/.env
+    image: postgres:10
+    container_name: superset_test_postgres
+    restart: unless-stopped
+    networks:
+      - test-network
+    expose:
+      - "5432"
+    volumes:
+      - db_home:/var/lib/postgresql/data
+
+  superset-tests-base:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    image: superset-tests-image
+
+  superset-tests-worker:
+    image: superset-tests-image
+    container_name: superset_test_worker
+    command: ["celery", "worker", "--app=superset.tasks.celery_app:app", "-Ofair", "-c", "2"]
+    restart: unless-stopped
+    networks:
+      - test-network
+    user: "root"
+    depends_on:
+      - postgres
+      - redis
+      - superset-tests-base
+    volumes: *superset-volumes
+    env_file: docker/.env
+    environment:
+      - SUPERSET_CONFIG=tests.superset_test_config
+      - SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@postgres:5432/test
+      - SUPERSET_TESTENV=true
+      - REDIS_HOST=redis
+      - TEST_MODULE="tests"
+
+  superset-tests-with-postgres:
+    image: superset-tests-image
+    container_name: superset_test_app
+    command: ["pytest", "tests"]
+    restart: unless-stopped
+    networks:
+      - test-network
+    user: "root"
+    depends_on:
+      - postgres
+      - redis
+      - superset-tests-base
+      - superset-tests-worker
+    volumes: *superset-volumes
+    env_file: docker/.env
+    environment:
+      - SUPERSET_CONFIG=tests.superset_test_config
+      - SUPERSET__SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://superset:superset@postgres:5432/test
+      - SUPERSET_TESTENV=true
+      - REDIS_HOST=redis
+      - TEST_MODULE="tests"
+
+volumes:
+  superset_home:
+    external: false
+  db_home:
+    external: false
+  redis:
+    external: false

--- a/docker/docker-run-tests.sh
+++ b/docker/docker-run-tests.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -14,33 +16,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-**/__pycache__/
-**/.git
-**/.apache_superset.egg-info
-**/.github
-**/.mypy_cache
-**/.pytest_cache
-**/.tox
-**/.vscode
-**/.idea
-**/.coverage
-**/.DS_Store
-**/.eggs
-**/.python-version
-**/*.egg-info
-**/*.bak
-**/*.db
-**/*.pyc
-**/*.sqllite
-**/*.swp
-**/.terser-plugin-cache/
-**/.storybook/
-**/node_modules/
+set -e
 
-docs/
-install/
-superset-frontend/cypress-base/
-superset-frontend/coverage/
-superset/static/assets/
-superset-websocket/dist/
-venv
+export SUPERSET_CONFIG=${SUPERSET_CONFIG:-tests.superset_test_config}
+export SUPERSET_TESTENV=true
+
+echo Running $@
+
+if [[ "${1}" == "celery" ]]; then
+  echo "Starting Celery worker..."
+  celery "${@:2}"
+elif [[ "${1}" == "pytest" ]]; then
+  echo "Running tests"
+  pytest "${@:2}"
+fi

--- a/docker/docker-run-tests.sh
+++ b/docker/docker-run-tests.sh
@@ -21,7 +21,8 @@ set -e
 export SUPERSET_CONFIG=${SUPERSET_CONFIG:-tests.superset_test_config}
 export SUPERSET_TESTENV=true
 
-echo Running $@
+superset db upgrade
+superset init
 
 if [[ "${1}" == "celery" ]]; then
   echo "Starting Celery worker..."


### PR DESCRIPTION
This WIP commit is to enable running tests through docker. The intended acceptance criteria of this commit would be that a dev could pull down a fresh clone of the Superset repo and, without any setup, configuration, or installs (aside from docker), be able to run the test suite via a `make` command.

This commit gets us most of the way there, but there were a few remaining issues still needing to be fixed:

1. When booting up for the first time, the `postgres` service should have a `test` db created and then have it migrated / initialized.
    1. You'll notice a `make` command `create-test-db`. This is not working, but it's _really_ close to what we'll need. I tested out the command on my local pg database and it works (creating `test` db when absent, otherwise doing nothing). But I ran out of time before I got it working through the docker-compose `postgres` service. This make command should probably be a dependency of the `pytest` make command so that it runs first.
    2. The migration/init is currently happening in the test bash script. That should probably be moved out of there. Perhaps it would be a make command.
2. The test suite currently has 29 failures (out of 1500 or so). Most of them are all for the same reason, having something to do with servicing a request out of order (?). This is a weird issue, but the good news is it's likely a small fix that, once identified, will make most of the tests pass.
3. The Makefile command currently runs the whole suite. This needs to be configurable to run a single file / test.
4. So far, this is just for postgres, but we'll want to enable the test suite to be run via mysql and sqlite (same as CI). Once the postgres version is ironed out, it should be relatively simple to follow the pattern for the other two.

cc @robdiciuccio @hughhhh @stevenuray 