### PR TITLE
fix: Tags owner metadata not showing properly

### DIFF
--- a/superset-frontend/src/components/MetadataBar/ContentConfig.tsx
+++ b/superset-frontend/src/components/MetadataBar/ContentConfig.tsx
@@ -90,7 +90,9 @@ const config = (contentType: ContentType) => {
         tooltip: (
           <div>
             <Info header={t('Created by')} text={contentType.createdBy} />
-            <Info header={t('Owners')} text={contentType.owners} />
+            {!!contentType.owners && (
+              <Info header={t('Owners')} text={contentType.owners} />
+            )}
             <Info header={t('Created on')} text={contentType.createdOn} />
           </div>
         ),

--- a/superset-frontend/src/components/MetadataBar/ContentType.ts
+++ b/superset-frontend/src/components/MetadataBar/ContentType.ts
@@ -51,7 +51,7 @@ export type LastModified = {
 export type Owner = {
   type: MetadataType.OWNER;
   createdBy: string;
-  owners: string[];
+  owners?: string[];
   createdOn: string;
   onClick?: (type: string) => void;
 };

--- a/superset-frontend/src/pages/AllEntities/index.tsx
+++ b/superset-frontend/src/pages/AllEntities/index.tsx
@@ -27,7 +27,12 @@ import { loadTags } from 'src/components/Tags/utils';
 import { getValue } from 'src/components/Select/utils';
 import AllEntitiesTable from 'src/features/allEntities/AllEntitiesTable';
 import Button from 'src/components/Button';
-import MetadataBar, { MetadataType } from 'src/components/MetadataBar';
+import MetadataBar, {
+  MetadataType,
+  Description,
+  Owner,
+  LastModified,
+} from 'src/components/MetadataBar';
 import { PageHeaderWithActions } from 'src/components/PageHeaderWithActions';
 import { fetchSingleTag } from 'src/features/tags/tags';
 import { Tag } from 'src/views/CRUD/types';
@@ -111,20 +116,22 @@ function AllEntities() {
     label: t('dataset name'),
   };
 
-  const items = [];
-  items.push({
+  const description: Description = {
     type: MetadataType.DESCRIPTION,
     value: tag?.description || '',
-  });
-  items.push({
+  };
+
+  const owner: Owner = {
+    type: MetadataType.OWNER,
+    createdBy: `${tag?.created_by.first_name} ${tag?.created_by.last_name}`,
+    createdOn: tag?.created_on_delta_humanized,
+  };
+  const lastModified: LastModified = {
     type: MetadataType.LAST_MODIFIED,
     value: tag?.changed_on_delta_humanized,
     modifiedBy: `${tag?.changed_by.first_name} ${tag?.changed_by.last_name}`,
-  });
-  items.push({
-    type: MetadataType.OWNER,
-    createdBy: `${tag?.created_by.first_name} ${tag?.created_by.last_name}`,
-  });
+  };
+  const items = [description, owner, lastModified];
 
   useEffect(() => {
     // fetch single tag met
@@ -132,7 +139,6 @@ function AllEntities() {
       fetchSingleTag(
         tagId,
         (tag: Tag) => {
-          console.log(tag);
           setTag(tag);
         },
         (error: Response) => {

--- a/superset/tags/api.py
+++ b/superset/tags/api.py
@@ -89,6 +89,7 @@ class TagRestApi(BaseSupersetModelRestApi):
         "changed_by.first_name",
         "changed_by.last_name",
         "changed_on_delta_humanized",
+        "created_on_delta_humanized",
         "created_by.first_name",
         "created_by.last_name",
     ]
@@ -103,6 +104,7 @@ class TagRestApi(BaseSupersetModelRestApi):
         "changed_by.first_name",
         "changed_by.last_name",
         "changed_on_delta_humanized",
+        "created_on_delta_humanized",
         "created_by.first_name",
         "created_by.last_name",
         "created_by",


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
On hovering over the tags metadata, owners was erroneously showing when there were no other owners, and created on had no data displayed. To fix this, I added created_on_delta_humanized to the tags payload in the backend and loaded this data into the metadata bar on the front end.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![image](https://github.com/apache/superset/assets/41238731/0c0c904f-11e2-4217-9242-8b5f7c218a38)

After:
![image](https://github.com/apache/superset/assets/41238731/6f25e291-2e9f-4e78-bba4-2ba8184e88a1)


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
