### PR TITLE
fix(security): patch CVEs in pyarrow, pyopenssl, requests, setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
     "python-dateutil",
     "python-dotenv", # optional dependencies for Flask but required for Superset, see https://flask.palletsprojects.com/en/stable/installation/#optional-dependencies
     "pygeohash",
-    "pyarrow>=16.1.0, <19", # before upgrading pyarrow, check that all db dependencies support this, see e.g. https://github.com/apache/superset/pull/34693
+    "pyarrow>=16.1.0, <21", # before upgrading pyarrow, check that all db dependencies support this, see e.g. https://github.com/apache/superset/pull/34693
     "pyyaml>=6.0.0, <7.0.0",
     "PyJWT>=2.4.0, <3.0",
     "redis>=5.0.0, <6.0",

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -25,6 +25,14 @@ filelock>=3.20.3,<4.0.0
 # Security: decompression bomb fix (required by aiohttp 3.13.3)
 brotli>=1.2.0,<2.0.0
 numexpr>=2.9.0
+# Security: CVE-2024-52338 (CRITICAL) - Deserialization of untrusted data in IPC/Parquet readers
+pyarrow>=20.0.0
+# Security: CVE-2026-27459 - pyopenssl certificate validation
+pyopenssl>=26.0.0
+# Security: CVE-2026-25645 (MEDIUM) - Insecure Temporary File
+requests>=2.33.0
+# Security: CVE-2026-23949 (HIGH) - Zip Slip path traversal via jaraco.context
+setuptools>=80.10.1,<81
 
 # 5.0.0 has a sensitive deprecation used in other libs
 # -> https://github.com/aio-libs/async-timeout/blob/master/CHANGES.rst#500-2024-10-31
@@ -47,4 +55,4 @@ openapi-schema-validator>=0.6.3
 # pkg_resources is deprecated and will be removed in setuptools 81+ (around 2025-11-30)
 # Known affected packages: Preset's 'clients' package
 # See docs/docs/contributing/pkg-resources-migration.md for details
-setuptools<81
+# (minimum version pinned above for CVE-2026-23949)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -291,8 +291,10 @@ prison==0.2.1
     # via flask-appbuilder
 prompt-toolkit==3.0.51
     # via click-repl
-pyarrow==16.1.0
-    # via apache-superset (pyproject.toml)
+pyarrow==20.0.0
+    # via
+    #   -r requirements/base.in
+    #   apache-superset (pyproject.toml)
 pyasn1==0.6.3
     # via
     #   pyasn1-modules
@@ -319,8 +321,10 @@ pyjwt==2.12.0
     #   redis
 pynacl==1.6.2
     # via paramiko
-pyopenssl==25.3.0
-    # via shillelagh
+pyopenssl==26.0.0
+    # via
+    #   -r requirements/base.in
+    #   shillelagh
 pyparsing==3.2.3
     # via apache-superset (pyproject.toml)
 pysocks==1.7.1
@@ -353,8 +357,9 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.33.0
     # via
+    #   -r requirements/base.in
     #   requests-cache
     #   shillelagh
 requests-cache==1.2.1
@@ -371,7 +376,7 @@ rsa==4.9.1
     # via google-auth
 selenium==4.32.0
     # via apache-superset (pyproject.toml)
-setuptools==80.9.0
+setuptools==80.10.1
     # via -r requirements/base.in
 shillelagh==1.4.3
     # via apache-superset (pyproject.toml)

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -710,7 +710,7 @@ psycopg2-binary==2.9.9
     # via apache-superset
 py-key-value-aio==0.4.4
     # via fastmcp
-pyarrow==16.1.0
+pyarrow==20.0.0
     # via
     #   -c requirements/base-constraint.txt
     #   apache-superset
@@ -778,7 +778,7 @@ pynacl==1.6.2
     # via
     #   -c requirements/base-constraint.txt
     #   paramiko
-pyopenssl==25.3.0
+pyopenssl==26.0.0
     # via
     #   -c requirements/base-constraint.txt
     #   shillelagh
@@ -865,7 +865,7 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.33.0
     # via
     #   -c requirements/base-constraint.txt
     #   docker
@@ -918,7 +918,7 @@ selenium==4.32.0
     #   apache-superset
 semver==3.0.4
     # via apache-superset-extensions-cli
-setuptools==80.9.0
+setuptools==80.10.1
     # via
     #   -c requirements/base-constraint.txt
     #   nodeenv


### PR DESCRIPTION
## Summary
- **pyarrow** 16.1.0 → 20.0.0 — CVE-2024-52338 (CRITICAL): Deserialization of untrusted data in IPC/Parquet readers
- **pyopenssl** 25.3.0 → 26.0.0 — CVE-2026-27459: Certificate validation issue
- **requests** 2.32.4 → 2.33.0 — CVE-2026-25645 (MEDIUM): Insecure Temporary File
- **setuptools** 80.9.0 → 80.10.1 — CVE-2026-23949 (HIGH): Zip Slip path traversal via re-vendored jaraco.context

Widens pyarrow upper bound in `pyproject.toml` from `<19` to `<21`.
Adds security minimum version pins in `requirements/base.in`.

Tracking: [sc-103280](https://app.shortcut.com/preset/story/103280)

## Test plan
- [ ] CI passes (unit tests, integration tests)
- [ ] Snyk scan confirms CVEs are resolved
- [ ] Verify no import/runtime regressions from pyarrow 20.x or pyopenssl 26.x