### PR TITLE
fix(dashboard): use light muted spinner for group-by display control loading state

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterControls/GroupByFilterCard.tsx
@@ -645,7 +645,7 @@ const GroupByFilterCard: FC<GroupByFilterCardProps> = ({
 
       {loading && (
         <div style={{ textAlign: 'center', marginTop: 8 }}>
-          <Loading position="inline" />
+          <Loading position="inline" size="s" muted />
         </div>
       )}
     </div>


### PR DESCRIPTION
### SUMMARY
The Group By dashboard display control (rendered under "Display controls" in the filter bar) showed a loading spinner while fetching its column options. It used `<Loading position="inline" />` with no size/opacity props, which falls back to the default full-opacity dark Superset spinner — visually out of place for an inline filter-bar control.

This changes it to `<Loading position="inline" size="s" muted />`, matching the light, subtle spinner used by every sibling component in the filter bar (`FilterValue.tsx`, `Vertical.tsx`, `Horizontal.tsx`) and the `Loading` component's own documented guidance for filter bars / inline elements.

Customer-reported issue.

### TESTING INSTRUCTIONS
Open a dashboard with a native "Group By" filter/display control backed by a dataset that must fetch column options. While it loads, the spinner should now be the light grey (muted, small) spinner rather than the dark Superset spinner. Existing `GroupByFilterCard.test.tsx` passes.

### ADDITIONAL INFORMATION
- [ ] Has associated issue
- [x] Bug fix