### PR TITLE
fix(dashboard): keep filter config modal within iframe

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from 'spec/helpers/testing-library';
+
+import { BaseForm, BaseModalBody, BaseModalWrapper } from './SharedStyles';
+
+test('filter config modal is bounded by its containing block', () => {
+  const { rerender } = render(
+    <BaseModalWrapper expanded={false} open>
+      <div>Modal content</div>
+    </BaseModalWrapper>,
+  );
+
+  const modal = document.querySelector('.ant-modal');
+  expect(modal).toBeInTheDocument();
+  expect(modal).toHaveStyleRule(
+    'width',
+    'min(880px, calc(100% - 32px))!important',
+  );
+  expect(modal).toHaveStyleRule('max-width', 'calc(100% - 32px)');
+  expect(modal).not.toHaveStyleRule('min-width', '880px');
+
+  rerender(
+    <BaseModalWrapper expanded open>
+      <div>Modal content</div>
+    </BaseModalWrapper>,
+  );
+  expect(document.querySelector('.ant-modal')).toHaveStyleRule(
+    'width',
+    'min(100%, calc(100% - 32px))!important',
+  );
+});
+
+test('filter config modal height propagates to its scrolling children', () => {
+  const { container } = render(
+    <BaseModalBody expanded={false}>
+      <BaseForm>
+        <div>Form content</div>
+      </BaseForm>
+    </BaseModalBody>,
+  );
+
+  const body = container.firstChild;
+  const form = container.querySelector('form');
+  expect(body).toHaveStyleRule('min-height', '0');
+  expect(form).toHaveStyleRule('height', '100%');
+  expect(form).toHaveStyleRule('min-height', '0');
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.tsx
@@ -31,13 +31,11 @@ export interface BaseModalBodyProps {
 }
 
 export const BaseModalWrapper = styled(StyledModal)<BaseModalWrapperProps>`
-  min-width: ${MIN_WIDTH}px;
-  width: ${({ expanded }) => (expanded ? '100%' : MIN_WIDTH)} !important;
-
-  @media (max-width: ${MIN_WIDTH + MODAL_MARGIN * 2}px) {
-    width: 100% !important;
-    min-width: auto;
-  }
+  width: ${({ expanded }) =>
+    `min(${expanded ? '100%' : `${MIN_WIDTH}px`}, calc(100% - ${
+      MODAL_MARGIN * 2
+    }px))`} !important;
+  max-width: calc(100% - ${MODAL_MARGIN * 2}px);
 
   .ant-modal-header {
     margin-bottom: 0;
@@ -75,9 +73,10 @@ export const BaseModalWrapper = styled(StyledModal)<BaseModalWrapperProps>`
 export const BaseModalBody = styled.div<BaseModalBodyProps>`
   display: flex;
   height: 100%;
-  min-height: 500px;
+  min-height: 0;
   flex-direction: row;
   flex: 1;
+  overflow: hidden;
 
   .filters-list {
     display: flex;
@@ -87,6 +86,8 @@ export const BaseModalBody = styled.div<BaseModalBodyProps>`
 
 export const BaseForm = styled(Form)`
   width: 100%;
+  height: 100%;
+  min-height: 0;
 `;
 
 export const BaseExpandButtonWrapper = styled.div`

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/ConfigModalSidebar/ConfigModalSidebar.tsx
@@ -36,14 +36,12 @@ import { FilterRemoval } from '../types';
 import { FILTER_TYPE, CUSTOMIZATION_TYPE } from '../DraggableFilter';
 import { isFilterId, isChartCustomizationId, isDivider } from '../utils';
 
-// max-height constrains the sidebar so its inner Collapse can scroll when
-// there are many filters (sc-101839). The parent height chain through the
-// antd Form is unreliable, so a viewport-relative max-height is used instead
-// of height: 100%.
 const StyledSidebarFlex = styled(Flex)`
   min-width: 290px;
   max-width: 290px;
-  max-height: 70vh;
+  height: 100%;
+  max-height: 100%;
+  min-height: 0;
   border-right: 1px solid ${({ theme }) => theme.colorBorderSecondary};
 `;
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -967,7 +967,7 @@ const FiltersConfigForm = (
   return (
     <Tabs
       allowOverflow={false}
-      contentHeight={`calc(100vh - ${theme.sizeUnit * 55}px)`}
+      fullHeight
       contentPadding={css`
         padding-top: ${theme.sizeUnit * 4}px;
       `}

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/DateFilterLabel.tsx
@@ -346,7 +346,6 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
 
   const popoverContent = (
     <ControlPopover
-      autoAdjustOverflow={false}
       trigger="click"
       placement="right"
       content={overlayContent}
@@ -359,7 +358,7 @@ export default function DateFilterLabel(props: DateFilterControlProps) {
       defaultOpen={show}
       open={show}
       onOpenChange={toggleOverlay}
-      overlayStyle={{ width: '600px' }}
+      overlayStyle={{ width: 'min(600px, calc(100% - 32px))' }}
       destroyOnHidden
       getPopupContainer={nodeTrigger =>
         isOverflowingFilterBar

--- a/superset-frontend/src/explore/components/controls/DateFilterControl/tests/DateFilterLabel.test.tsx
+++ b/superset-frontend/src/explore/components/controls/DateFilterControl/tests/DateFilterLabel.test.tsx
@@ -99,8 +99,11 @@ test('DateFilter popover should attach to document.body when not overflowing', (
 
   userEvent.click(screen.getByText(NO_TIME_RANGE));
 
-  const popover = document.querySelector('.time-range-popover');
+  const popover = document.querySelector<HTMLElement>('.time-range-popover');
   expect(popover?.parentElement).toBe(document.body);
+  expect(popover).toHaveStyle({
+    width: 'min(600px, calc(100% - 32px))',
+  });
 });
 
 test('DateFilter popover should attach to parent node when overflowing in filter bar', () => {


### PR DESCRIPTION
### SUMMARY

Fixes [SC-111114](https://app.shortcut.com/preset/story/111114), where the native-filter configuration surface and its time-range editor can be clipped when all of Superset is hosted in a constrained iframe.

The reported screenshot and source inspection exposed two related layout assumptions:

- the filter modal enforced an 880px minimum width and only relaxed it through a viewport media query;
- its descendants independently sized themselves with `70vh` / `calc(100vh - ...)`, so the sidebar and tab content did not derive their height from the modal;
- the 600px time-range popover explicitly disabled `ControlPopover` overflow adjustment, allowing a corner placement to extend outside the iframe.

This change repairs those constraints at their enforcement points without trying to detect an embedded context:

- cap normal and expanded modal widths to their actual containing block, with a 16px gutter, instead of enforcing a hard minimum;
- complete the modal/form flex height chain and let the sidebar and tabs consume that height rather than independently measuring the viewport;
- cap the time-range editor to its popup container and restore `ControlPopover`'s built-in flip/shift behavior.

Focused regression tests protect both the modal width/height constraints and the time-range popover width.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

The customer-provided before screenshot is attached to [SC-111114](https://app.shortcut.com/preset/story/111114). A local Superset server was not available in this isolated worktree for an after screenshot; the responsive constraints are covered by the focused component tests below.

### TESTING INSTRUCTIONS

Automated:

```bash
cd superset-frontend
npx jest --runInBand --silent \
  src/dashboard/components/nativeFilters/ConfigModal/SharedStyles.test.tsx \
  src/explore/components/controls/DateFilterControl/tests/DateFilterLabel.test.tsx
# 2 suites passed, 8 tests passed

cd ..
pre-commit run
# all applicable hooks passed, including oxfmt, oxlint, custom rules,
# stylelint, and targeted frontend type checking
```

Manual verification:

1. Host the full Superset application in an iframe narrower than the browser window.
2. Open a dashboard, enter edit mode, and open **Add or edit display controls**.
3. Create/edit a time-range filter, enable **Pre-filter available values**, then open the **Time range** editor.
4. Verify the filter modal retains a gutter inside the iframe, its sidebar and configuration panes scroll within the modal, and the time-range editor flips/shifts without crossing the iframe edge.
5. Repeat at a normal desktop width and verify the modal remains 880px wide and the time-range editor remains 600px wide.
6. Expand the modal and verify it fills the available iframe width while retaining the gutter.

### ADDITIONAL INFORMATION

- [x] Has associated issue: [SC-111114](https://app.shortcut.com/preset/story/111114)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
