### PR TITLE
fix(dataset): expose dataset certification controls

### DIFF
--- a/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.tsx
+++ b/superset-frontend/src/components/Datasource/DatasourceModal/DatasourceModal.test.tsx
@@ -22,6 +22,7 @@ import {
   waitFor,
   fireEvent,
   cleanup,
+  userEvent,
   defaultStore as store,
 } from 'spec/helpers/testing-library';
 import fetchMock from 'fetch-mock';
@@ -133,6 +134,81 @@ describe('DatasourceModal', () => {
           call.options?.method === 'put',
       );
     expect(JSON.parse(putCall?.options?.body as string).editors).toEqual([1]);
+  });
+
+  test('saves dataset certification from Settings without dropping Extra metadata', async () => {
+    cleanup();
+    renderAndWait({
+      ...mockedProps,
+      datasource: {
+        ...mockedProps.datasource,
+        extra: JSON.stringify({
+          custom_key: { enabled: true },
+          warning_markdown: 'Use only finalized records',
+        }),
+      } as typeof mockedProps.datasource & { extra: string },
+    });
+
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+    const certifiedBy = await screen.findByPlaceholderText('Certified by');
+    fireEvent.change(certifiedBy, { target: { value: 'E2E Team' } });
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const details = screen.getByPlaceholderText('Certification details');
+    fireEvent.change(details, {
+      target: { value: 'Reviewed for production' },
+    });
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    fireEvent.click(screen.getByTestId('datasource-modal-save'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      const putCall = fetchMock.callHistory
+        .calls()
+        .find(
+          call =>
+            call.url.includes('/api/v1/dataset/7') &&
+            call.options?.method === 'put',
+        );
+      expect(putCall).toBeDefined();
+
+      const payload = JSON.parse(putCall?.options?.body as string);
+      expect(JSON.parse(payload.extra)).toEqual({
+        custom_key: { enabled: true },
+        warning_markdown: 'Use only finalized records',
+        certification: {
+          certified_by: 'E2E Team',
+          details: 'Reviewed for production',
+        },
+      });
+    });
+  });
+
+  test('shows existing dataset certification in Settings', async () => {
+    cleanup();
+    renderAndWait({
+      ...mockedProps,
+      datasource: {
+        ...mockedProps.datasource,
+        extra: JSON.stringify({
+          certification: {
+            certified_by: 'Data Platform Team',
+            details: 'Source of truth',
+          },
+        }),
+      } as typeof mockedProps.datasource & { extra: string },
+    });
+
+    await userEvent.click(await screen.findByRole('tab', { name: 'Settings' }));
+
+    expect(await screen.findByPlaceholderText('Certified by')).toHaveValue(
+      'Data Platform Team',
+    );
+    expect(screen.getByPlaceholderText('Certification details')).toHaveValue(
+      'Source of truth',
+    );
   });
 
   test('should render error dialog', async () => {

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/DatasourceEditor.tsx
@@ -108,6 +108,10 @@ import {
 } from '../../FoldersEditor/treeUtils';
 import FoldersEditor from '../../FoldersEditor';
 import { DatasourceFolder } from 'src/explore/components/DatasourcePanel/types';
+import {
+  getDatasetCertification,
+  setDatasetCertification,
+} from './datasetCertification';
 
 const extensionsRegistry = getExtensionsRegistry();
 
@@ -1631,6 +1635,49 @@ function DatasourceEditor({
     onDatasourceChange,
   ]);
 
+  const renderCertificationFieldset = useCallback(() => {
+    const certification = getDatasetCertification(datasource.extra);
+
+    return isSqla ? (
+      <Fieldset
+        title={t('Certification')}
+        item={certification}
+        onChange={updatedCertification => {
+          onDatasourceChange({
+            ...datasource,
+            extra: setDatasetCertification(
+              datasource.extra,
+              updatedCertification,
+            ),
+          });
+        }}
+      >
+        <Field
+          fieldKey="certified_by"
+          label={t('Certified by')}
+          description={t('Person or group that has certified this dataset')}
+          control={
+            <TextControl
+              controlId="dataset_certified_by"
+              placeholder={t('Certified by')}
+            />
+          }
+        />
+        <Field
+          fieldKey="certification_details"
+          label={t('Certification details')}
+          description={t('Details of the dataset certification')}
+          control={
+            <TextControl
+              controlId="dataset_certification_details"
+              placeholder={t('Certification details')}
+            />
+          }
+        />
+      </Fieldset>
+    ) : null;
+  }, [datasource, onDatasourceChange, isSqla]);
+
   const renderSettingsFieldset = useCallback(
     () => (
       <Fieldset
@@ -2548,7 +2595,10 @@ function DatasourceEditor({
         children: (
           <Row gutter={16}>
             <Col xs={24} md={12}>
-              <FormContainer>{renderSettingsFieldset()}</FormContainer>
+              <FormContainer>
+                {renderCertificationFieldset()}
+                {renderSettingsFieldset()}
+              </FormContainer>
             </Col>
             <Col xs={24} md={12}>
               <FormContainer>{renderAdvancedFieldset()}</FormContainer>
@@ -2578,6 +2628,7 @@ function DatasourceEditor({
       folders,
       folderCount,
       handleFoldersChange,
+      renderCertificationFieldset,
       renderSettingsFieldset,
       renderAdvancedFieldset,
       // `renderSpatialTab` is intentionally retained (see its definition above)

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/datasetCertification.ts
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/datasetCertification.ts
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type DatasetCertification = Record<string, unknown> & {
+  certified_by?: string;
+  certification_details?: string;
+};
+
+type JsonObject = Record<string, unknown>;
+
+const isJsonObject = (value: unknown): value is JsonObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const parseExtra = (extra?: string): JsonObject | undefined => {
+  if (!extra?.trim()) {
+    return {};
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(extra);
+    return isJsonObject(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const getDatasetCertification = (
+  extra?: string,
+): DatasetCertification => {
+  const certification = parseExtra(extra)?.certification;
+  if (!isJsonObject(certification)) {
+    return {};
+  }
+
+  return {
+    certified_by:
+      typeof certification.certified_by === 'string'
+        ? certification.certified_by
+        : undefined,
+    certification_details:
+      typeof certification.details === 'string'
+        ? certification.details
+        : undefined,
+  };
+};
+
+export const setDatasetCertification = (
+  extra: string | undefined,
+  { certified_by, certification_details }: DatasetCertification,
+): string => {
+  const parsedExtra = parseExtra(extra);
+
+  // Do not replace malformed raw metadata while the user is correcting it in
+  // the adjacent Extra editor.
+  if (!parsedExtra) {
+    return extra ?? '';
+  }
+
+  if (certified_by || certification_details) {
+    const existingCertification = parsedExtra.certification;
+    parsedExtra.certification = {
+      ...(isJsonObject(existingCertification) ? existingCertification : {}),
+      certified_by: certified_by || undefined,
+      details: certification_details || undefined,
+    };
+  } else {
+    delete parsedExtra.certification;
+  }
+
+  return JSON.stringify(parsedExtra, null, 2);
+};

--- a/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/datasetCertification.test.ts
+++ b/superset-frontend/src/components/Datasource/components/DatasourceEditor/tests/datasetCertification.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  getDatasetCertification,
+  setDatasetCertification,
+} from '../datasetCertification';
+
+test('reads dataset certification from Extra JSON', () => {
+  expect(
+    getDatasetCertification(
+      JSON.stringify({
+        certification: {
+          certified_by: 'Data Platform Team',
+          details: 'Source of truth',
+        },
+      }),
+    ),
+  ).toEqual({
+    certified_by: 'Data Platform Team',
+    certification_details: 'Source of truth',
+  });
+});
+
+test('writes dataset certification without discarding other Extra metadata', () => {
+  const result = setDatasetCertification(
+    JSON.stringify({
+      custom_key: { enabled: true },
+      warning_markdown: 'Use only finalized records',
+    }),
+    {
+      certified_by: 'E2E Team',
+      certification_details: 'Reviewed for production',
+    },
+  );
+
+  expect(JSON.parse(result)).toEqual({
+    custom_key: { enabled: true },
+    warning_markdown: 'Use only finalized records',
+    certification: {
+      certified_by: 'E2E Team',
+      details: 'Reviewed for production',
+    },
+  });
+});
+
+test('clearing dataset certification preserves other Extra metadata', () => {
+  const result = setDatasetCertification(
+    JSON.stringify({
+      certification: {
+        certified_by: 'Data Platform Team',
+        details: 'Source of truth',
+      },
+      warning_markdown: 'Use only finalized records',
+    }),
+    {},
+  );
+
+  expect(JSON.parse(result)).toEqual({
+    warning_markdown: 'Use only finalized records',
+  });
+});
+
+test('editing certification does not overwrite malformed Extra JSON', () => {
+  expect(
+    setDatasetCertification('{"custom_key":', {
+      certified_by: 'Data Platform Team',
+    }),
+  ).toBe('{"custom_key":');
+});


### PR DESCRIPTION
### SUMMARY

The reported recording does not certify the dataset: it opens the Metrics tab and fills the certification fields for a metric. Dataset-level certification is stored separately in `SqlaTable.extra.certification`. The dataset list already receives `extra` from the combined datasource API and renders `CertifiedBadge` when that dataset-level key is present.

The user-facing gap is that metric and column certification have dedicated fields, while certifying the dataset itself requires hand-editing raw Extra JSON. This makes the two scopes easy to confuse and leaves a valid list renderer with no dataset-level value to display.

This change adds an explicit **Certification** section to Edit Dataset → Settings. The fields read and write the existing `extra.certification` contract, so no model/API/migration change is needed. Updates merge with custom Extra keys and warning metadata, clearing the fields removes only certification, and malformed Extra JSON is never overwritten.

Shortcut: https://app.shortcut.com/preset/story/115268

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

**Before:** Dataset certification was available only by entering the nested certification object in the raw Extra JSON field. The visible certification fields under Metrics/Columns certified only that child item.

**After:** Edit Dataset → Settings has dedicated dataset-level “Certified by” and “Certification details” fields. Saving them produces the dataset-level metadata that the existing Datasets list badge consumes.

### TESTING INSTRUCTIONS

Automated:

```bash
cd superset-frontend
npx jest --runInBand --silent \
  src/components/Datasource/components/DatasourceEditor/tests/datasetCertification.test.ts \
  src/components/Datasource/DatasourceModal/DatasourceModal.test.tsx
# 2 suites, 21 tests passed

npx jest --runInBand --silent \
  src/pages/DatasetList/DatasetList.behavior.test.tsx \
  -t 'certified dataset shows badge'
# 1 passed

pre-commit run
# all applicable hooks passed, including frontend formatting, lint, custom rules,
# stylelint, and targeted TypeScript checking
```

Manual:

1. Open Data → Datasets and edit an SQLAlchemy dataset.
2. Open Settings and fill “Certified by” and “Certification details”.
3. Save, return to the dataset list, and confirm the certified badge and tooltip appear beside the dataset name.
4. Reopen Settings and confirm both values are populated.
5. Confirm unrelated Extra JSON keys and `warning_markdown` remain intact.

### ADDITIONAL INFORMATION

- [x] Has associated issue: [SC-115268](https://app.shortcut.com/preset/story/115268)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
