### PR TITLE
fix(charts): sort chart types by display name

### DIFF
--- a/superset-frontend/src/components/ListView/types.ts
+++ b/superset-frontend/src/components/ListView/types.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { type JsonObject } from '@superset-ui/core';
 import { type ReactNode } from 'react';
 
 export interface SortColumn {
@@ -102,6 +103,7 @@ export interface ListViewFetchDataConfig {
   pageSize: number;
   sortBy: SortColumn[];
   filters: ListViewFilterValue[];
+  extraQueryParams?: JsonObject;
 }
 
 export interface InternalFilter extends ListViewFilterValue {

--- a/superset-frontend/src/pages/ChartList/ChartList.listview.test.tsx
+++ b/superset-frontend/src/pages/ChartList/ChartList.listview.test.tsx
@@ -20,7 +20,12 @@ import fetchMock from 'fetch-mock';
 import { mockUserSubjectsBootstrapData } from 'spec/helpers/mockBootstrapData';
 import { screen, waitFor, within } from 'spec/helpers/testing-library';
 import userEvent from '@testing-library/user-event';
-import { isFeatureEnabled } from '@superset-ui/core';
+import rison from 'rison';
+import {
+  ChartMetadata,
+  getChartMetadataRegistry,
+  isFeatureEnabled,
+} from '@superset-ui/core';
 import {
   mockCharts,
   mockHandleResourceExport,
@@ -277,6 +282,45 @@ test('sorts table when clicking column headers', async () => {
     const latestCall = lastModifiedSortCalls.at(-1);
     expect(latestCall?.url).toContain('order_direction:asc');
   });
+});
+
+test('sends friendly chart type names for server-side sorting', async () => {
+  const registry = getChartMetadataRegistry();
+  registry
+    .registerValue(
+      'slug_a',
+      new ChartMetadata({ name: 'Zulu', thumbnail: '', behaviors: [] }),
+    )
+    .registerValue(
+      'slug_z',
+      new ChartMetadata({ name: 'Alpha', thumbnail: '', behaviors: [] }),
+    );
+
+  try {
+    renderChartList(mockUser);
+
+    const table = await screen.findByTestId('listview-table');
+    await userEvent.click(within(table).getByTitle('Type'));
+
+    await waitFor(() => {
+      const typeSortCall = fetchMock.callHistory
+        .calls(/chart\/\?q/)
+        .find(call => call.url.includes('order_column:viz_type'));
+      expect(typeSortCall).toBeDefined();
+
+      const query = new URL(
+        typeSortCall!.url,
+        'http://localhost',
+      ).searchParams.get('q');
+      expect(rison.decode(query!)).toMatchObject({
+        order_column: 'viz_type',
+        viz_type_names: { slug_a: 'Zulu', slug_z: 'Alpha' },
+      });
+    });
+  } finally {
+    registry.remove('slug_a');
+    registry.remove('slug_z');
+  }
 });
 
 test('displays chart data correctly in table rows', async () => {

--- a/superset-frontend/src/pages/ChartList/index.tsx
+++ b/superset-frontend/src/pages/ChartList/index.tsx
@@ -71,6 +71,7 @@ import {
   ListViewFilterOperator as FilterOperator,
   DashboardCrossLinks,
   type ListViewProps,
+  type ListViewFetchDataConfig,
   type ListViewFilters,
   type ListViewFilter,
 } from 'src/components';
@@ -260,10 +261,32 @@ function ChartList(props: ChartListProps) {
     },
     setResourceCollection: setCharts,
     hasPerm,
-    fetchData,
+    fetchData: fetchChartData,
     toggleBulkSelect,
     refreshData,
   } = useListViewResource<Chart>('chart', t('chart'), addDangerToast);
+
+  const fetchData = useCallback(
+    (config: ListViewFetchDataConfig) =>
+      fetchChartData({
+        ...config,
+        ...(config.sortBy[0]?.id === 'viz_type'
+          ? {
+              extraQueryParams: {
+                viz_type_names: Object.fromEntries(
+                  registry
+                    .keys()
+                    .map(vizType => [
+                      vizType,
+                      registry.get(vizType)?.name || vizType,
+                    ]),
+                ),
+              },
+            }
+          : {}),
+      }),
+    [fetchChartData],
+  );
 
   const chartIds = useMemo(() => charts.map(c => c.id), [charts]);
   const { roles } = useSelector<any, UserWithPermissionsAndRoles>(

--- a/superset-frontend/src/views/CRUD/hooks.test.tsx
+++ b/superset-frontend/src/views/CRUD/hooks.test.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { renderHook, act } from '@testing-library/react';
+import rison from 'rison';
 import { waitFor } from 'spec/helpers/testing-library';
 import { JsonResponse, SupersetClient } from '@superset-ui/core';
 
@@ -549,6 +550,35 @@ test('useListViewResource: uses desc sort direction when desc is true', async ()
 
   const endpoint = findEndpoint(getSpy, '/api/v1/chart/?q=');
   expect(endpoint).toContain('order_direction:desc');
+});
+
+test('useListViewResource: includes extra list query parameters', async () => {
+  const getSpy = jest.spyOn(SupersetClient, 'get').mockResolvedValue({
+    json: { result: [], count: 0 },
+  } as unknown as JsonResponse);
+
+  const { result } = renderHook(() =>
+    useListViewResource('chart', 'Charts', jest.fn()),
+  );
+
+  await act(async () => {
+    await result.current.fetchData({
+      pageIndex: 0,
+      pageSize: 25,
+      sortBy: [{ id: 'viz_type' }],
+      filters: [],
+      extraQueryParams: {
+        viz_type_names: { slug_a: 'Zulu', slug_z: 'Alpha' },
+      },
+    });
+  });
+
+  const endpoint = findEndpoint(getSpy, '/api/v1/chart/?q=');
+  const query = new URL(endpoint, 'http://localhost').searchParams.get('q');
+  expect(rison.decode(query!)).toMatchObject({
+    order_column: 'viz_type',
+    viz_type_names: { slug_a: 'Zulu', slug_z: 'Alpha' },
+  });
 });
 
 // useSingleViewResource

--- a/superset-frontend/src/views/CRUD/hooks.ts
+++ b/superset-frontend/src/views/CRUD/hooks.ts
@@ -156,6 +156,7 @@ export function useListViewResource<D extends object = any>(
       pageSize,
       sortBy,
       filters: filterValues,
+      extraQueryParams,
     }: FetchDataConfig) => {
       const requestId = latestRequestIdRef.current + 1;
       latestRequestIdRef.current = requestId;
@@ -165,6 +166,7 @@ export function useListViewResource<D extends object = any>(
         pageIndex,
         pageSize,
         sortBy,
+        extraQueryParams,
       };
       lastFetchDataConfigRef.current = config;
       // set loading state, cache the last config for refreshing data.
@@ -187,6 +189,7 @@ export function useListViewResource<D extends object = any>(
         }));
 
       const queryParams = rison.encode_uri({
+        ...extraQueryParams,
         order_column: sortBy[0].id,
         order_direction: sortBy[0].desc ? 'desc' : 'asc',
         page: pageIndex,

--- a/superset/charts/api.py
+++ b/superset/charts/api.py
@@ -16,6 +16,7 @@
 # under the License.
 # pylint: disable=too-many-lines
 import logging
+from contextvars import ContextVar
 from datetime import datetime
 from io import BytesIO
 from typing import Any, cast, Optional
@@ -27,6 +28,9 @@ from flask_appbuilder.hooks import before_request
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from flask_babel import ngettext
 from marshmallow import ValidationError
+from sqlalchemy import asc, case, desc
+from sqlalchemy.orm import Query
+from sqlalchemy.orm.util import AliasedClass
 from werkzeug.wrappers import Response as WerkzeugResponse
 from werkzeug.wsgi import FileWrapper
 
@@ -142,9 +146,74 @@ _CHART_PURGE_BINDING = SoftDeleteBinding(
     delete_failed=ChartDeleteFailedError,
 )
 
+_MAX_VIZ_TYPE_NAMES = 256
+_MAX_VIZ_TYPE_NAME_LENGTH = 512
+_viz_type_names: ContextVar[dict[str, str] | None] = ContextVar(
+    "chart_viz_type_names", default=None
+)
+
+
+def _validate_viz_type_names(value: Any) -> dict[str, str]:
+    """Validate the client registry used to order chart visualization types."""
+    if not isinstance(value, dict):
+        raise ValueError("viz_type_names must be an object")
+    if len(value) > _MAX_VIZ_TYPE_NAMES:
+        raise ValueError(
+            f"viz_type_names cannot contain more than {_MAX_VIZ_TYPE_NAMES} entries"
+        )
+
+    for viz_type, name in value.items():
+        if not isinstance(viz_type, str) or not isinstance(name, str):
+            raise ValueError("viz_type_names keys and values must be strings")
+        if (
+            len(viz_type) > _MAX_VIZ_TYPE_NAME_LENGTH
+            or len(name) > _MAX_VIZ_TYPE_NAME_LENGTH
+        ):
+            raise ValueError(
+                "viz_type_names keys and values cannot exceed "
+                f"{_MAX_VIZ_TYPE_NAME_LENGTH} characters"
+            )
+    return value.copy()
+
+
+class ChartSQLAInterface(SQLAInterface):
+    """Chart model interface with request-scoped friendly viz type ordering."""
+
+    def apply_order_by(
+        self,
+        query: Query,
+        order_column: str,
+        order_direction: str,
+        aliases_mapping: dict[str, AliasedClass] | None = None,
+        bypass_many_to_many: bool = False,
+        add_pk: bool = False,
+    ) -> Query:
+        viz_type_names = _viz_type_names.get()
+        if order_column != "viz_type" or not viz_type_names:
+            return super().apply_order_by(
+                query,
+                order_column,
+                order_direction,
+                aliases_mapping=aliases_mapping,
+                bypass_many_to_many=bypass_many_to_many,
+                add_pk=add_pk,
+            )
+
+        order_expression = case(
+            viz_type_names,
+            value=Slice.viz_type,
+            else_=Slice.viz_type,
+        )
+        direction = asc if order_direction == "asc" else desc
+        order_by_columns = [direction(order_expression)]
+        primary_key = self.get_pk()
+        if add_pk and primary_key is not None:
+            order_by_columns.append(direction(primary_key))
+        return query.order_by(*order_by_columns)
+
 
 class ChartRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
-    datamodel = SQLAInterface(Slice)
+    datamodel = ChartSQLAInterface(Slice)
 
     resource_name = "chart"
     allow_browser_login = True
@@ -421,6 +490,23 @@ class ChartRestApi(SoftDeleteApiMixin, BaseSupersetModelRestApi):
         for row, row_id in zip(data.get("result", []), ids, strict=False):
             if row_id in extra_editors_by_id:
                 row["extra_editors"] = extra_editors_by_id[row_id]
+
+    def get_list_headless(self, **kwargs: Any) -> Response:
+        """Use client chart metadata names for SQL ordering before pagination."""
+        args = kwargs.get("rison", {})
+        if args.get("order_column") != "viz_type" or "viz_type_names" not in args:
+            return super().get_list_headless(**kwargs)
+
+        try:
+            viz_type_names = _validate_viz_type_names(args["viz_type_names"])
+        except ValueError as ex:
+            return self.response_400(message=str(ex))
+
+        token = _viz_type_names.set(viz_type_names)
+        try:
+            return super().get_list_headless(**kwargs)
+        finally:
+            _viz_type_names.reset(token)
 
     @expose("/<pk>/deck_layers/", methods=("GET",))
     @protect()

--- a/tests/integration_tests/charts/api_tests.py
+++ b/tests/integration_tests/charts/api_tests.py
@@ -1502,6 +1502,51 @@ class TestChartApi(ApiEditorsTestCaseMixin, InsertChartMixin, SupersetTestCase):
         data = json.loads(rv.data.decode("utf-8"))
         assert data["count"] == 5
 
+    @pytest.mark.usefixtures("load_energy_table_with_slice")
+    def test_get_charts_orders_friendly_viz_types_before_pagination(self):
+        """Chart API: friendly chart type ordering happens before pagination."""
+        admin = self.get_user("admin")
+        charts = [
+            self.insert_chart("friendly_type_sort_a", [admin.id], 1, viz_type="slug_a"),
+            self.insert_chart(
+                "friendly_type_sort_middle", [admin.id], 1, viz_type="middle"
+            ),
+            self.insert_chart("friendly_type_sort_z", [admin.id], 1, viz_type="slug_z"),
+        ]
+        self.login(ADMIN_USERNAME)
+
+        arguments = {
+            "filters": [
+                {
+                    "col": "slice_name",
+                    "opr": "sw",
+                    "value": "friendly_type_sort_",
+                }
+            ],
+            "columns": ["slice_name", "viz_type"],
+            "order_column": "viz_type",
+            "order_direction": "asc",
+            "page_size": 2,
+            "viz_type_names": {"slug_a": "zulu", "slug_z": "alpha"},
+        }
+
+        try:
+            pages = []
+            for page in (0, 1):
+                arguments["page"] = page
+                uri = f"api/v1/chart/?q={rison.dumps(arguments)}"
+                rv = self.get_assert_metric(uri, "get_list")
+                assert rv.status_code == 200
+                data = json.loads(rv.data.decode("utf-8"))
+                assert data["count"] == 3
+                pages.extend(item["viz_type"] for item in data["result"])
+
+            assert pages == ["slug_z", "middle", "slug_a"]
+        finally:
+            for chart in charts:
+                db.session.delete(chart)
+            db.session.commit()
+
     @pytest.fixture
     def load_energy_charts(self):
         with app.app_context():


### PR DESCRIPTION
### SUMMARY

Fixes [Shortcut SC-112958](https://app.shortcut.com/preset/story/112958).

The chart list rendered `viz_type` through the frontend chart metadata registry, but the paginated Chart API ordered the underlying `Slice.viz_type` slug. As a result, clicking **Type** produced an order that did not match the labels users saw.

This change sends the active registry's slug-to-display-name mapping only when Type sorting is requested. The Chart API validates that bounded mapping and applies it as a request-scoped SQL `CASE` ordering expression before `OFFSET`/`LIMIT`, retaining the primary-key tie breaker for stable pagination. Unknown/custom slugs fall back to their slug, matching the cell renderer. The shared list resource hook now supports typed, per-request extra query parameters without allowing them to override pagination or order controls.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Not applicable. Behavior-only change: Type sorting now follows the friendly labels displayed in the column rather than the stored slugs.

### TESTING INSTRUCTIONS

Automated:

- `npm run test -- src/views/CRUD/hooks.test.tsx src/pages/ChartList/ChartList.listview.test.tsx` — 54 passed
- `.venv/bin/python -m pytest -q tests/integration_tests/charts/api_tests.py -k 'friendly_viz_types or get_charts_filter' --maxfail=1` — 2 passed
- `npm run lint -- src/components/ListView/types.ts src/pages/ChartList/index.tsx src/pages/ChartList/ChartList.listview.test.tsx src/views/CRUD/hooks.ts src/views/CRUD/hooks.test.tsx` — passed
- `pre-commit run` on all staged files — passed, including mypy, frontend type checking, ruff, pylint, oxfmt, and oxlint

Manual:

1. Create enough charts with several types to span multiple chart-list pages.
2. Open **Charts** and click **Type**.
3. Verify ascending order follows the displayed friendly names across page boundaries.
4. Click **Type** again and verify descending order also follows the displayed names.

### ADDITIONAL INFORMATION

- [x] Has associated issue: [SC-112958](https://app.shortcut.com/preset/story/112958)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
