### PR TITLE
[vulnerability][superset] pin fast-uri →3.1.6 (4 CVEs)

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -20814,9 +20814,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -405,7 +405,7 @@
     "eslint-plugin-jest-dom": {
       "eslint": "$eslint"
     },
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "fast-xml-parser": "^5.8.0",
     "http-proxy-middleware": "^2.0.10",
     "jest-circus": "^30.4.0",


### PR DESCRIPTION
### SUMMARY

`fast-uri` is a **transitive** dependency of `superset-frontend` (pulled in via `ajv@^3.0.1` and `@rjsf/utils@^4.1.2`). An existing `overrides` pin in `superset-frontend/package.json` forced it onto the 3.x line at `^3.1.5`, which resolved to **3.1.5** — vulnerable to four HIGH-severity advisories:

| CVE | GHSA | Description | Fixed in (3.x) |
|-----|------|-------------|----------------|
| CVE-2026-75899 | GHSA-fph4-wmhf-6fwf | SSRF via repeated hostname percent-decoding (double decoding) | 3.1.6 |
| CVE-2026-75975 | GHSA-f65p-4m7j-42xc | SSRF via malformed IPv6 normalization (syntactic validation) | 3.1.6 |
| CVE-2026-76172 | GHSA-jqff-g426-hqxp | Host confusion via percent-encoded scheme normalization (hex encoding) | 3.1.6 |
| CVE-2026-75931 | GHSA-5jgf-p345-68v8 | Host confusion via skipped IDN canonicalization (interpretation conflict) | 3.1.6 |

**3.1.6 is the earliest 3.x release fixing all four CVEs** (per the GitHub Advisory Database).

**Remediation (contained, non-breaking):** the existing override is raised from `^3.1.5` to `^3.1.6`, and the lockfile resolves to **3.1.7** (latest 3.x, fully patched — same version already shipped in `superset-embedded-sdk` via #43796).

**Why stay on the 3.x line:** `ajv` requires `fast-uri@^3.0.1`, so the override must remain within 3.x. A jump to 4.x would break `ajv`'s constraint. No parent major bump is required — this is a lockfile + one-line override change only.

**Scope of other workspaces:**
- `superset-embedded-sdk` — already at 3.1.7 (patched by #43796), no change.
- `superset-websocket` — does not depend on `fast-uri`, no change.

> Note: `fast-uri` and the `ajv`/`@rjsf` chain are upstream `apache/superset` dependencies; this same override bump is a candidate for an upstream contribution.

### TESTING INSTRUCTIONS

- `cd superset-frontend && npm ls fast-uri` resolves to `3.1.7` (single hoisted copy via the override).
- `npm install --package-lock-only` produces no further change to the `fast-uri` resolution.
- Diff is limited to the `overrides.fast-uri` range and the single hoisted `node_modules/fast-uri` lockfile entry (version/resolved/integrity), with the integrity hash verified against the npm registry (`npm view fast-uri@3.1.7 dist.integrity`).

### ADDITIONAL INFORMATION

- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
