### PR TITLE
feat(embedded): diagnose guest-token header size budgets

### DIFF
--- a/docs/developer_docs/extensions/overview.md
+++ b/docs/developer_docs/extensions/overview.md
@@ -47,14 +47,14 @@ Extension developers have access to pre-built UI components via `@apache-superse
 
 ## Next Steps
 
-- **[Quick Start](./quick-start)** - Build your first extension with a complete walkthrough
-- **[Architecture](./architecture)** - Design principles and system overview
-- **[Dependencies](./dependencies)** - Managing dependencies and understanding API stability
-- **[Contribution Types](./contribution-types)** - Available extension points
-- **[Development](./development)** - Project structure, APIs, and development workflow
-- **[Deployment](./deployment)** - Packaging and deploying extensions
-- **[MCP Integration](./mcp)** - Adding AI agent capabilities using extensions
-- **[Security](./security)** - Security considerations and best practices
-- **[Storage](./storage)** - Managed storage API for persisting extension data
-- **[Tasks](./tasks)** - Framework for creating and managing long running tasks
-- **[Community Extensions](./registry)** - Browse extensions shared by the community
+- **[Quick Start](./quick-start.md)** - Build your first extension with a complete walkthrough
+- **[Architecture](./architecture.md)** - Design principles and system overview
+- **[Dependencies](./dependencies.md)** - Managing dependencies and understanding API stability
+- **[Contribution Types](./contribution-types.md)** - Available extension points
+- **[Development](./development.md)** - Project structure, APIs, and development workflow
+- **[Deployment](./deployment.md)** - Packaging and deploying extensions
+- **[MCP Integration](./mcp.md)** - Adding AI agent capabilities using extensions
+- **[Security](./security.md)** - Security considerations and best practices
+- **[Storage](./storage.md)** - Managed storage API for persisting extension data
+- **[Tasks](./tasks.md)** - Framework for creating and managing long running tasks
+- **[Community Extensions](./registry.md)** - Browse extensions shared by the community

--- a/docs/docs/using-superset/embedding.mdx
+++ b/docs/docs/using-superset/embedding.mdx
@@ -145,3 +145,48 @@ The following URL parameters can be passed through the `urlParams` option in `da
 - **Row-level security** — pass `rls` rules in the guest token request to restrict which rows are visible to the embedded user.
 - **Allowed domains** — restrict which host origins can embed a dashboard by setting **Allowed Domains** per-dashboard in the _Embed_ settings modal. Superset checks the request's `Referer` header against this list before serving the embedded view; an empty list allows any origin, so configure this explicitly for production.
 - **Redacted errors** — API responses to a guest token report a generic `An error occurred while fetching the data.` instead of the underlying error, since engine errors quote catalog, schema, table and column names. Errors Superset raises itself — access denials, timeouts, payload validation — keep their message, and the full error is always available in the server logs.
+
+
+## Guest-token request-header size diagnostics
+
+A successful guest-token mint does not guarantee the token can pass through your
+deployment's proxies. Limits apply to the **encoded JWT bytes plus header
+overhead**, not the number of RLS rules or identifiers. A proxy can reject the
+subsequent authentication request before it reaches Superset, including an HTTP
+400 HTML response instead of JSON. A 400 alone does not establish a size problem.
+
+Operators can set a deployment-specific diagnostic budget in `superset_config.py`:
+
+```python
+# Example only: choose a budget for your complete proxy path.
+GUEST_TOKEN_HEADER_MAX_BYTES = 16 * 1024
+```
+
+The default is `None` (no budget warnings). Positive integer budgets count UTF-8
+bytes of `GUEST_TOKEN_HEADER_NAME`, `: `, the encoded token, and `\r\n`
+(four framing bytes). Only sizes **strictly greater** than the budget warn;
+equality does not. This is consistent diagnostic accounting, not a prediction of
+every proxy's wire-level accounting, HTTP/2 compression, or total-header limits.
+Leave a safety margin and validate your actual deployment, including custom
+header names. Zero or negative values disable budget warnings.
+
+Issuance audit metadata includes `token_bytes`, `header_bytes`,
+`header_budget_bytes`, and `header_budget_exceeded`. Issuance remains HTTP 200
+with the same token and response shape. The embedded bootstrap exposes the budget
+and configured header name; reload the iframe after changing deployment config.
+The embedded client measures initial and refreshed tokens and warns in the
+developer console with sizes only. Initial authentication failures get a targeted
+suggestion only when the request's token exceeds the budget and the failure has
+no status or HTTP 400/431; other statuses and ambiguous in-flight
+refreshes use the generic error. Refresh warnings do not restart authentication.
+These diagnostics do not record JWTs, decoded claims, RLS SQL, or request headers.
+
+[AWS Application Load Balancer quotas](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html)
+list a non-adjustable 16 K single-header limit. Increasing a Superset diagnostic
+budget does not increase that limit or add large-token support.
+
+To reduce payload size, replace large inline RLS ID lists with a compact
+entitlements-table subquery where supported by your database. Keep the same
+tenant/user restrictions, derive identity from your trusted token-issuing
+backend, and verify equivalent row access and query performance before rollout.
+Do not remove RLS or broaden entitlements to make a token smaller.

--- a/docs/docs/using-superset/number-formatting.mdx
+++ b/docs/docs/using-superset/number-formatting.mdx
@@ -89,4 +89,4 @@ Use these when a metric's underlying values are stored in meters or centimeters 
 
 ## Currency
 
-Some chart types also expose currency-specific formatting, including a dynamic mode that reads the currency from a column value. See [Dynamic Currency Formatting](./creating-your-first-dashboard#dynamic-currency-formatting) for details.
+Some chart types also expose currency-specific formatting, including a dynamic mode that reads the currency from a column value. See [Dynamic Currency Formatting](./creating-your-first-dashboard.mdx#dynamic-currency-formatting) for details.

--- a/docs/scripts/generate-api-tag-pages.mjs
+++ b/docs/scripts/generate-api-tag-pages.mjs
@@ -161,7 +161,7 @@ function main() {
     let table = '| Method | Endpoint | Path |\n';
     table += '|--------|----------|------|\n';
     for (const ep of endpoints) {
-      table += `| \`${ep.method}\` | [${ep.summary}](./${ep.slug}) | \`${ep.path}\` |\n`;
+      table += `| \`${ep.method}\` | [${ep.summary}](./${ep.slug}.api.mdx) | \`${ep.path}\` |\n`;
     }
 
     // Generate the new MDX content

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -40,7 +40,8 @@
       // Using /ui path matches the established pattern used throughout the Superset codebase
       "@apache-superset/core/components": ["./src/types/apache-superset-core"],
       "@site/*": ["./*"],
-      "*": ["./src/*", "./node_modules/*"]
+      // Let package imports use normal resolution, including @types fallbacks.
+      "*": ["./src/*"]
     }
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx", "./src/**/*.d.ts"],

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -8284,35 +8284,10 @@ escape-string-regexp@^5.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
   integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
-eslint-scope@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^4.1.1"
-
 esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
-
-esrecurse@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
-  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
-  dependencies:
-    estraverse "^5.2.0"
-
-estraverse@^4.1.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
-  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
-
-estraverse@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
-  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 estree-util-attach-comments@^3.0.0:
   version "3.0.0"
@@ -11136,16 +11111,6 @@ minimist@^1.2.0:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
-minimizer-webpack-plugin@^5.6.1:
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz#289922a4c96c4ed1ddb76b8a00bd8074e89a2f7f"
-  integrity sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==
-  dependencies:
-    "@jridgewell/trace-mapping" "^0.3.25"
-    jest-worker "^27.4.5"
-    schema-utils "^4.3.0"
-    terser "^5.31.1"
 
 minimizer-webpack-plugin@^5.7.0:
   version "5.8.0"
@@ -15163,7 +15128,7 @@ webpack-virtual-modules@^0.6.2:
   resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz#057faa9065c8acf48f24cb57ac0e77739ab9a7e8"
   integrity sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==
 
-webpack@^5.110.1:
+webpack@^5.110.1, webpack@^5.88.1, webpack@^5.95.0:
   version "5.110.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.110.1.tgz#d662d8ff1866fcb58a6b8af09c86bc6f1b9c5c1d"
   integrity sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==
@@ -15182,32 +15147,6 @@ webpack@^5.110.1:
     graceful-fs "^4.2.11"
     mime-db "^1.54.0"
     minimizer-webpack-plugin "^5.7.0"
-    neo-async "^2.6.2"
-    schema-utils "^4.3.3"
-    tapable "^2.3.0"
-    watchpack "^2.5.2"
-    webpack-sources "^3.5.1"
-
-webpack@^5.88.1, webpack@^5.95.0:
-  version "5.109.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.109.2.tgz#b58dc289561c3282db35c210a99379a836a4c28d"
-  integrity sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==
-  dependencies:
-    "@types/estree" "^1.0.8"
-    "@types/json-schema" "^7.0.15"
-    "@webassemblyjs/ast" "^1.14.1"
-    "@webassemblyjs/wasm-edit" "^1.14.1"
-    "@webassemblyjs/wasm-parser" "^1.14.1"
-    acorn "^8.16.0"
-    browserslist "^4.28.1"
-    chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.24.4"
-    es-module-lexer "^2.1.0"
-    eslint-scope "5.1.1"
-    events "^3.2.0"
-    graceful-fs "^4.2.11"
-    mime-db "^1.54.0"
-    minimizer-webpack-plugin "^5.6.1"
     neo-async "^2.6.2"
     schema-utils "^4.3.3"
     tapable "^2.3.0"

--- a/superset-frontend/src/embedded/guestTokenDiagnostics.test.ts
+++ b/superset-frontend/src/embedded/guestTokenDiagnostics.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { TextEncoder } from 'util';
+import {
+  measureGuestToken,
+  guestAuthenticationMessage,
+} from './guestTokenDiagnostics';
+
+beforeAll(() => {
+  Object.assign(global, { TextEncoder });
+});
+
+test.each([
+  [20, true],
+  [21, false],
+  [22, false],
+  [null, false],
+  [0, false],
+  [-1, false],
+])('header budget %s: exceeded=%s', (budget, exceeded) => {
+  expect(measureGuestToken('é'.repeat(3), 'X-Custom-É', budget)).toEqual({
+    tokenBytes: 6,
+    headerBytes: 21,
+    headerBudgetBytes: budget && budget > 0 ? budget : null,
+    headerBudgetExceeded: exceeded,
+  });
+});
+
+test('default header accounting and safe metadata only', () => {
+  const size = measureGuestToken('secret-token', undefined, 1);
+  expect(size.headerBytes).toBe(28);
+  expect(JSON.stringify(size)).not.toContain('secret-token');
+  expect(guestAuthenticationMessage(size)).toContain('may exceed');
+});
+
+test('no size evidence uses generic authentication message', () => {
+  expect(guestAuthenticationMessage()).not.toContain('may exceed');
+  expect(guestAuthenticationMessage(measureGuestToken('t'))).not.toContain(
+    'may exceed',
+  );
+});

--- a/superset-frontend/src/embedded/guestTokenDiagnostics.ts
+++ b/superset-frontend/src/embedded/guestTokenDiagnostics.ts
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { t } from '@apache-superset/core/translation';
+
+export type GuestTokenSize = {
+  tokenBytes: number;
+  headerBytes: number;
+  headerBudgetBytes: number | null;
+  headerBudgetExceeded: boolean;
+};
+
+/** Measure the encoded token without decoding or retaining credentials. */
+export function measureGuestToken(
+  token: string,
+  headerName = 'X-GuestToken',
+  budget?: number | null,
+): GuestTokenSize {
+  const encoder = new TextEncoder();
+  const tokenBytes = encoder.encode(token).length;
+  // HTTP/1-style accounting: name + ": " + value + CRLF, not wire compression.
+  const headerBytes = tokenBytes + encoder.encode(headerName).length + 4;
+  const headerBudgetBytes =
+    typeof budget === 'number' && Number.isSafeInteger(budget) && budget > 0
+      ? budget
+      : null;
+  return {
+    tokenBytes,
+    headerBytes,
+    headerBudgetBytes,
+    headerBudgetExceeded:
+      headerBudgetBytes !== null && headerBytes > headerBudgetBytes,
+  };
+}
+
+/** Diagnose from size evidence only; never inspect or log proxy response bodies. */
+export function guestAuthenticationMessage(
+  size?: GuestTokenSize,
+  error?: unknown,
+): string {
+  const status =
+    typeof error === 'object' && error !== null && 'status' in error
+      ? error.status
+      : undefined;
+  // Explicit auth/server failures have other causes. Some non-JSON proxy
+  // failures lose their status during parsing, so size remains the evidence.
+  const possibleHeaderFailure =
+    status === undefined || status === 400 || status === 431;
+  return size?.headerBudgetExceeded && possibleHeaderFailure
+    ? t(
+        'Embedded authentication failed. The guest token may exceed the request-header size limit. Reduce the token payload; large inline RLS lists can be replaced with an entitlements-table lookup.',
+      )
+    : t(
+        'Something went wrong with embedded authentication. Check the dev console for details.',
+      );
+}

--- a/superset-frontend/src/embedded/index.test.tsx
+++ b/superset-frontend/src/embedded/index.test.tsx
@@ -18,7 +18,14 @@
  */
 // Mark this file as a module so its top-level declarations stay file-scoped
 // (the file has no imports; modules are loaded via require() inside tests).
-export {};
+import { TextEncoder } from 'util';
+
+Object.assign(global, { TextEncoder });
+
+const mockConfig = {
+  GUEST_TOKEN_HEADER_NAME: 'X-Custom-Guest',
+  GUEST_TOKEN_HEADER_MAX_BYTES: 100,
+};
 
 // Stable mock references so they survive jest.resetModules() between tests
 // (a factory-created jest.fn() would otherwise be replaced on each reset,
@@ -59,13 +66,14 @@ jest.mock('src/components/UiConfigContext', () => ({
 
 // Capture the guestToken handler that start() is wired to, so tests can
 // re-trigger the handshake and assert the retry behavior.
+const mockSwitchboardInit = jest.fn();
 const mockSwitchboard = {
   handler: undefined as ((arg: { guestToken: string }) => void) | undefined,
 };
 jest.mock('@superset-ui/switchboard', () => ({
   __esModule: true,
   default: {
-    init: jest.fn(),
+    init: mockSwitchboardInit,
     start: jest.fn(),
     defineMethod: (name: string, fn: (arg: { guestToken: string }) => void) => {
       if (name === 'guestToken') {
@@ -76,7 +84,8 @@ jest.mock('@superset-ui/switchboard', () => ({
   },
 }));
 
-jest.mock('src/setup/setupClient', () => jest.fn(), { virtual: true });
+const mockSetupClient = jest.fn();
+jest.mock('src/setup/setupClient', () => mockSetupClient, { virtual: true });
 
 jest.mock('src/views/store', () => ({
   store: {
@@ -113,6 +122,7 @@ jest.mock('react-dom/client', () => ({
 jest.mock('src/utils/getBootstrapData', () => ({
   __esModule: true,
   default: () => ({
+    config: mockConfig,
     embedded: { dashboard_id: '123', allowed_domains: [] },
     common: {
       application_root: '/',
@@ -147,55 +157,142 @@ function sendHandshake() {
   );
 }
 
-describe('embedded/index.tsx', () => {
-  beforeEach(() => {
-    jest.resetModules();
-    mockSwitchboard.handler = undefined;
-    mockSetupPlugins.mockReset();
-    mockSetupAGGridModules.mockReset();
-    mockLogging.error.mockClear();
-    mockGetMeWithRole.mockReset();
-    mockGetMeWithRole.mockResolvedValue({ result: { roles: {} } });
-    document.body.innerHTML = '<div id="app"></div>';
-  });
+beforeEach(() => {
+  jest.resetModules();
+  mockSwitchboard.handler = undefined;
+  mockSetupPlugins.mockReset();
+  mockSetupAGGridModules.mockReset();
+  mockLogging.error.mockClear();
+  mockGetMeWithRole.mockReset();
+  mockGetMeWithRole.mockResolvedValue({ result: { roles: {} } });
+  document.body.innerHTML = '<div id="app"></div>';
+});
 
-  test('initializes AG Grid modules on bootstrap', async () => {
-    mockSetupPlugins.mockImplementation(() => undefined);
+test('initializes AG Grid modules on bootstrap', async () => {
+  mockSetupPlugins.mockImplementation(() => undefined);
+  require('./index');
+  await flush();
+
+  expect(mockSetupAGGridModules).toHaveBeenCalled();
+});
+
+test('retries plugin setup after setupPlugins rejects, then bootstraps the user', async () => {
+  // First plugin setup throws; the second attempt (after a re-handshake) succeeds.
+  mockSetupPlugins
+    .mockImplementationOnce(() => {
+      throw new Error('setupPlugins failed');
+    })
+    .mockImplementation(() => undefined);
+
+  require('./index');
+  await flush();
+
+  sendHandshake();
+  expect(mockSwitchboard.handler).toBeDefined();
+
+  // First guest token: plugin setup rejects, start() resets the guard and
+  // recreates pluginsReady so a retry can re-run setup.
+  mockSwitchboard.handler!({ guestToken: 'token-1' });
+  await flush();
+  expect(mockLogging.error).toHaveBeenCalled();
+  expect(mockGetMeWithRole).not.toHaveBeenCalled();
+  // The user gets a visible failure message rather than a blank #app.
+  expect(document.getElementById('app')!.innerHTML).toContain(
+    'Something went wrong loading the dashboard',
+  );
+
+  // Second guest token retries: plugin setup now succeeds and the user loads.
+  mockSwitchboard.handler!({ guestToken: 'token-2' });
+  await flush();
+  expect(mockSetupPlugins).toHaveBeenCalledTimes(2);
+  expect(mockGetMeWithRole).toHaveBeenCalled();
+});
+
+test.each([
+  ['short', { status: 400, text: '<html>proxy error</html>' }, false],
+  ['short', { status: 401 }, false],
+  ['x'.repeat(100), { status: 401 }, false],
+  ['x'.repeat(100), { status: 500 }, false],
+  ['x'.repeat(100), new SyntaxError('private response body'), true],
+])(
+  'authentication failure uses size evidence, not response content',
+  async (token, error, targeted) => {
+    mockGetMeWithRole.mockRejectedValue(error);
     require('./index');
     await flush();
-
-    expect(mockSetupAGGridModules).toHaveBeenCalled();
-  });
-
-  test('retries plugin setup after setupPlugins rejects, then bootstraps the user', async () => {
-    // First plugin setup throws; the second attempt (after a re-handshake) succeeds.
-    mockSetupPlugins
-      .mockImplementationOnce(() => {
-        throw new Error('setupPlugins failed');
-      })
-      .mockImplementation(() => undefined);
-
-    require('./index');
-    await flush();
-
     sendHandshake();
-    expect(mockSwitchboard.handler).toBeDefined();
-
-    // First guest token: plugin setup rejects, start() resets the guard and
-    // recreates pluginsReady so a retry can re-run setup.
-    mockSwitchboard.handler!({ guestToken: 'token-1' });
+    mockSwitchboard.handler!({ guestToken: token });
     await flush();
-    expect(mockLogging.error).toHaveBeenCalled();
-    expect(mockGetMeWithRole).not.toHaveBeenCalled();
-    // The user gets a visible failure message rather than a blank #app.
-    expect(document.getElementById('app')!.innerHTML).toContain(
-      'Something went wrong loading the dashboard',
+    expect(
+      document.getElementById('app')!.textContent?.includes('may exceed'),
+    ).toBe(targeted);
+    expect(JSON.stringify(mockLogging.error.mock.calls)).not.toContain(
+      'private response body',
     );
-
-    // Second guest token retries: plugin setup now succeeds and the user loads.
-    mockSwitchboard.handler!({ guestToken: 'token-2' });
+    expect(JSON.stringify(mockLogging.error.mock.calls)).not.toContain(
+      '<html>',
+    );
+    // Failed authentication still permits the existing retry.
+    mockGetMeWithRole.mockResolvedValue({ result: { roles: {} } });
+    mockSwitchboard.handler!({ guestToken: 'replacement' });
     await flush();
-    expect(mockSetupPlugins).toHaveBeenCalledTimes(2);
-    expect(mockGetMeWithRole).toHaveBeenCalled();
-  });
+    expect(mockGetMeWithRole).toHaveBeenCalledTimes(2);
+  },
+);
+
+test('oversized refresh updates diagnostics without restarting successful auth', async () => {
+  mockLogging.warn.mockClear();
+  require('./index');
+  await flush();
+  sendHandshake();
+  mockSwitchboard.handler!({ guestToken: 'short' });
+  await flush();
+  mockSwitchboard.handler!({ guestToken: 'x'.repeat(100) });
+  await flush();
+  expect(mockGetMeWithRole).toHaveBeenCalledTimes(1);
+  expect(mockLogging.warn).toHaveBeenLastCalledWith(
+    'Guest token exceeds configured request-header budget',
+    {
+      tokenBytes: 100,
+      headerBytes: 118,
+      headerBudgetBytes: 100,
+      headerBudgetExceeded: true,
+    },
+  );
+  expect(mockSetupClient).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      guestToken: 'x'.repeat(100),
+      guestTokenHeaderName: 'X-Custom-Guest',
+    }),
+  );
+});
+
+test('refresh during pending authentication does not misattribute size evidence', async () => {
+  let rejectRequest: (error: unknown) => void = () => {};
+  mockGetMeWithRole.mockReturnValue(
+    new Promise((_resolve, reject) => {
+      rejectRequest = reject;
+    }),
+  );
+  require('./index');
+  await flush();
+  sendHandshake();
+  mockSwitchboard.handler!({ guestToken: 'x'.repeat(100) });
+  await flush();
+  mockSwitchboard.handler!({ guestToken: 'short' });
+  rejectRequest({ status: 400 });
+  await flush();
+  expect(document.getElementById('app')!.textContent).not.toContain(
+    'may exceed',
+  );
+  expect(mockGetMeWithRole).toHaveBeenCalledTimes(1);
+});
+
+test('Switchboard does not log credential-bearing message bodies', async () => {
+  require('./index');
+  await flush();
+  sendHandshake();
+  expect(mockSwitchboardInit).toHaveBeenLastCalledWith(
+    expect.objectContaining({ debug: false }),
+  );
 });

--- a/superset-frontend/src/embedded/index.tsx
+++ b/superset-frontend/src/embedded/index.tsx
@@ -49,6 +49,11 @@ import {
 import { embeddedApi } from './api';
 import { getDataMaskChangeTrigger } from './utils';
 import { validateMessageEvent } from './originValidation';
+import {
+  measureGuestToken,
+  guestAuthenticationMessage,
+  GuestTokenSize,
+} from './guestTokenDiagnostics';
 
 // Defer plugin setup until after the language pack loads to prevent t() calls in
 // plugin control panel configs from being cached in English before translations are ready.
@@ -177,6 +182,7 @@ if (!window.parent || window.parent === window) {
 let displayedUnauthorizedToast = false;
 let root: Root | null = null;
 let started = false;
+let guestTokenSize: GuestTokenSize | undefined;
 
 /**
  * If there is a problem with the guest token, we will start getting
@@ -209,8 +215,10 @@ function start() {
     endpoint: '/api/v1/me/roles/',
   });
   return pluginsReady.then(
-    () =>
-      getMeWithRole().then(
+    () => {
+      // Snapshot at dispatch, not at handshake: plugin loading can overlap refresh.
+      const requestTokenSize = guestTokenSize;
+      return getMeWithRole().then(
         ({ result }) => {
           // fill in some missing bootstrap data
           // (because at pageload, we don't have any auth yet)
@@ -225,18 +233,18 @@ function start() {
           }
           root.render(<EmbeddedApp />);
         },
-        err => {
+        (error: unknown) => {
           // something is most likely wrong with the guest token; reset the guard
           // so a rehandshake with a valid token can retry.
-          logging.error(err);
-          showFailureMessage(
-            t(
-              'Something went wrong with embedded authentication. Check the dev console for details.',
-            ),
-          );
+          // A refresh while the request is in flight makes attribution ambiguous.
+          const size =
+            requestTokenSize === guestTokenSize ? requestTokenSize : undefined;
+          logging.error('Embedded authentication failed', size);
+          showFailureMessage(guestAuthenticationMessage(size, error));
           started = false;
         },
-      ),
+      );
+    },
     err => {
       // setupPlugins() or setupCodeOverrides() threw while preparing plugins;
       // reset the guard and recreate pluginsReady so a retry actually re-runs
@@ -258,6 +266,17 @@ function start() {
  * Configures SupersetClient with the correct settings for the embedded dashboard page.
  */
 function setupGuestClient(guestToken: string) {
+  guestTokenSize = measureGuestToken(
+    guestToken,
+    bootstrapData.config?.GUEST_TOKEN_HEADER_NAME,
+    bootstrapData.config?.GUEST_TOKEN_HEADER_MAX_BYTES,
+  );
+  if (guestTokenSize.headerBudgetExceeded) {
+    logging.warn(
+      'Guest token exceeds configured request-header budget',
+      guestTokenSize,
+    );
+  }
   setupClient({
     appRoot: applicationRoot(),
     guestToken,
@@ -268,18 +287,19 @@ function setupGuestClient(guestToken: string) {
 
 window.addEventListener('message', function embeddedPageInitializer(event) {
   if (!validateMessageEvent(event, bootstrapData.embedded?.allowed_domains)) {
-    log('ignoring message unrelated to embedded comms', event);
+    log('ignoring message unrelated to embedded comms');
     return;
   }
 
   const port = event.ports?.[0];
   if (event.data.handshake === 'port transfer' && port) {
-    log('message port received', event);
+    log('message port received');
 
     Switchboard.init({
       port,
       name: 'superset',
-      debug: debugMode,
+      // Switchboard debug logs message bodies, including guest-token credentials.
+      debug: false,
     });
 
     Switchboard.defineMethod(

--- a/superset-frontend/src/types/bootstrapTypes.ts
+++ b/superset-frontend/src/types/bootstrapTypes.ts
@@ -181,7 +181,10 @@ export interface CommonBootstrapData {
 export interface BootstrapData {
   user?: BootstrapUser;
   common: CommonBootstrapData;
-  config?: any;
+  config?: {
+    GUEST_TOKEN_HEADER_NAME?: string;
+    GUEST_TOKEN_HEADER_MAX_BYTES?: number | null;
+  };
   embedded?: {
     dashboard_id: string;
     // Domains allowed to embed this dashboard. An empty/undefined list means

--- a/superset/config.py
+++ b/superset/config.py
@@ -3029,6 +3029,9 @@ GUEST_ROLE_NAME = "Public"
 GUEST_TOKEN_JWT_SECRET = CHANGE_ME_GUEST_TOKEN_JWT_SECRET
 GUEST_TOKEN_JWT_ALGO = "HS256"  # noqa: S105
 GUEST_TOKEN_HEADER_NAME = "X-GuestToken"  # noqa: S105
+# Diagnostic budget for UTF-8 bytes of "header-name: encoded-token\r\n".
+# None disables size warnings, not issuance or authentication. Deployment-specific.
+GUEST_TOKEN_HEADER_MAX_BYTES: int | None = None
 GUEST_TOKEN_JWT_EXP_SECONDS = 300  # 5 minutes
 # Audience for the Superset guest token used in embedded mode.
 # Can be a string or a callable. Defaults to WEBDRIVER_BASEURL.

--- a/superset/embedded/view.py
+++ b/superset/embedded/view.py
@@ -97,7 +97,12 @@ class EmbeddedView(BaseSupersetView):
 
         bootstrap_data = {
             "config": {
-                "GUEST_TOKEN_HEADER_NAME": current_app.config["GUEST_TOKEN_HEADER_NAME"]
+                "GUEST_TOKEN_HEADER_NAME": current_app.config[
+                    "GUEST_TOKEN_HEADER_NAME"
+                ],
+                "GUEST_TOKEN_HEADER_MAX_BYTES": current_app.config[
+                    "GUEST_TOKEN_HEADER_MAX_BYTES"
+                ],
             },
             "common": common_bootstrap_payload(),
             "embedded": {

--- a/superset/security/api.py
+++ b/superset/security/api.py
@@ -245,15 +245,23 @@ class SecurityRestApi(BaseSupersetApi):
                 body["rls"],
                 **({"datasets": body["datasets"]} if "datasets" in body else {}),
             )
-            logger.info(
-                "Guest token issued: %s",
-                build_guest_token_audit_payload(
-                    issuer_user_id=get_user_id(),
-                    source_ip=request.remote_addr,
-                    body=body,
-                    token=token,
-                ),
+            audit_payload = build_guest_token_audit_payload(
+                issuer_user_id=get_user_id(),
+                source_ip=request.remote_addr,
+                body=body,
+                token=token,
+                header_name=current_app.config["GUEST_TOKEN_HEADER_NAME"],
+                header_budget_bytes=current_app.config["GUEST_TOKEN_HEADER_MAX_BYTES"],
             )
+            logger.info("Guest token issued: %s", audit_payload)
+            if audit_payload["header_budget_exceeded"]:
+                logger.warning(
+                    "Guest token exceeds configured request-header budget: "
+                    "token_bytes=%s header_bytes=%s header_budget_bytes=%s",
+                    audit_payload["token_bytes"],
+                    audit_payload["header_bytes"],
+                    audit_payload["header_budget_bytes"],
+                )
             return self.response(200, token=token)
         except EmbeddedDashboardNotFoundError as error:
             return self.response_400(message=error.message)

--- a/superset/security/guest_token.py
+++ b/superset/security/guest_token.py
@@ -31,6 +31,8 @@ def build_guest_token_audit_payload(
     source_ip: Optional[str],
     body: dict[str, Any],
     token: str,
+    header_name: str = "X-GuestToken",
+    header_budget_bytes: Optional[int] = None,
 ) -> dict[str, Any]:
     """Build security-relevant metadata for a guest-token issuance event.
 
@@ -40,7 +42,17 @@ def build_guest_token_audit_payload(
     """
     resources = body.get("resources") or []
     rls = body.get("rls") or []
+    token_bytes = len(token.encode("utf-8"))
+    # HTTP/1-style accounting: name + colon-space + value + CRLF.
+    header_bytes = token_bytes + len(header_name.encode("utf-8")) + 4
+    budget = (
+        header_budget_bytes if header_budget_bytes and header_budget_bytes > 0 else None
+    )
     return {
+        "token_bytes": token_bytes,
+        "header_bytes": header_bytes,
+        "header_budget_bytes": budget,
+        "header_budget_exceeded": budget is not None and header_bytes > budget,
         "issuer_user_id": issuer_user_id,
         "source_ip": source_ip,
         "resources": [

--- a/tests/integration_tests/embedded/test_view.py
+++ b/tests/integration_tests/embedded/test_view.py
@@ -52,17 +52,30 @@ def _extract_bootstrap_data(response_data: bytes) -> dict[str, Any]:
     "superset.extensions.feature_flag_manager._feature_flags",
     EMBEDDED_SUPERSET=True,
 )
-def test_get_embedded_dashboard(client: FlaskClient[Any]):  # noqa: F811
+@pytest.mark.parametrize("budget", [None, 16384])
+def test_get_embedded_dashboard(
+    client: FlaskClient[Any],  # noqa: F811
+    budget: int | None,
+) -> None:
     dash = db.session.query(Dashboard).filter_by(slug="births").first()
     embedded = EmbeddedDashboardDAO.upsert(dash, [])
     db.session.flush()
     uri = f"embedded/{embedded.uuid}"
-    response = client.get(uri)
+    with mock.patch.dict(
+        client.application.config,
+        GUEST_TOKEN_HEADER_NAME="X-Custom-Guest",  # noqa: S106
+        GUEST_TOKEN_HEADER_MAX_BYTES=budget,
+    ):
+        response = client.get(uri)
     assert response.status_code == 200
     # The bootstrap payload exposes the (empty) allowed-domains list so the
     # frontend can validate postMessage origins.
     bootstrap = _extract_bootstrap_data(response.data)
     assert bootstrap["embedded"]["allowed_domains"] == []
+    assert bootstrap["config"] == {
+        "GUEST_TOKEN_HEADER_NAME": "X-Custom-Guest",
+        "GUEST_TOKEN_HEADER_MAX_BYTES": budget,
+    }
 
 
 @pytest.mark.usefixtures("load_birth_names_dashboard_with_slices")

--- a/tests/unit_tests/security/guest_token_audit_test.py
+++ b/tests/unit_tests/security/guest_token_audit_test.py
@@ -17,6 +17,11 @@
 """Tests for guest-token issuance audit metadata."""
 
 import hashlib
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
 
 from superset.security.guest_token import build_guest_token_audit_payload
 
@@ -72,3 +77,53 @@ def test_build_guest_token_audit_payload_omits_rls_clause_text() -> None:
     # Clause text (which can carry data values) is not recorded.
     assert "secret_value = 'pii'" not in str(payload)
     assert payload["rls_datasets"] == [7]
+
+
+@pytest.mark.parametrize(
+    "budget,exceeded",
+    [(20, True), (21, False), (22, False), (None, False), (0, False), (-1, False)],
+)
+def test_guest_token_size_budget(budget: int | None, exceeded: bool) -> None:
+    """Budget includes UTF-8 header name, colon-space, token and CRLF."""
+    payload = build_guest_token_audit_payload(
+        None, None, {}, "é" * 3, header_name="X-Custom-É", header_budget_bytes=budget
+    )
+    assert payload["token_bytes"] == 6
+    assert payload["header_bytes"] == 21
+    assert payload["header_budget_exceeded"] is exceeded
+
+
+@pytest.mark.parametrize("budget", [None, 19, 20, 21])
+def test_guest_token_issuance_preserves_response(budget: int | None) -> None:
+    """Diagnostics neither reject issuance nor change the encoded token or grants."""
+    from superset.security.api import SecurityRestApi
+
+    app = Flask(__name__)
+    app.config.update(
+        GUEST_TOKEN_HEADER_NAME="X-Test",  # noqa: S106
+        GUEST_TOKEN_HEADER_MAX_BYTES=budget,
+    )
+    api = MagicMock()
+    token = "encodedjwt"  # noqa: S105
+    api.appbuilder.sm.create_guest_access_token.return_value = token
+    body = {
+        "user": {"username": "guest"},
+        "resources": [],
+        "rls": [{"clause": "private_sql = 1"}],
+    }
+    with (
+        app.test_request_context(json=body),
+        patch("superset.security.api.guest_token_create_schema") as schema,
+        patch("superset.security.api.get_user_id", return_value=1),
+        patch("superset.security.api.logger") as log,
+    ):
+        schema.load.return_value = body
+        result = inspect.unwrap(SecurityRestApi.guest_token)(api)
+    api.response.assert_called_once_with(200, token=token)
+    assert result is api.response.return_value
+    api.appbuilder.sm.create_guest_access_token.assert_called_once_with(
+        body["user"], body["resources"], body["rls"]
+    )
+    assert log.warning.called is (budget is not None and budget < 20)
+    assert token not in str(log.mock_calls)
+    assert "private_sql" not in str(log.mock_calls)


### PR DESCRIPTION
### SUMMARY

Add diagnostics for encoded guest tokens that may exceed deployment request-header budgets. Related: [SC-113432](https://app.shortcut.com/preset/story/113432) (diagnostics-only; does not resolve the transport limit).

- Extend issuance audit metadata with token bytes, calculated header bytes, configured budget, and exceeded flag; warn with sizes only. Preserve mint HTTP 200, response shape, JWT bytes, and authorization/RLS.
- Measure initial/refreshed embedded tokens using the configured header name. Provide a targeted suggestion only with oversized-token evidence and HTTP 400/431 or unavailable status (including non-JSON errors). Other failures remain generic.
- Snapshot metadata at auth dispatch; suppress ambiguous attribution after in-flight refresh. Preserve requests, started guard, and existing retry behavior; no preflight rejection.
- Stop logging raw auth errors or credential-bearing Switchboard messages. New diagnostics contain no JWT, decoded claims, SQL, or raw headers.
- Document budgeting and the entitlements-table workaround without promising large-token support.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No browser screenshots available locally.

Before: generic embedded-authentication failure and raw error logging.
After, only with size evidence: “Embedded authentication failed. The guest token may exceed the request-header size limit. Reduce the token payload; large inline RLS lists can be replaced with an entitlements-table lookup.”

### TESTING INSTRUCTIONS

Added coverage for below/at/above budgets, UTF-8/custom-header accounting, disabled budgets, privacy, mint response preservation, bootstrap configuration, non-JSON failures, unrelated auth failures, refresh warnings, stale request attribution, and unchanged retry/start behavior.

Run in a configured development environment:

    pytest tests/unit_tests/security/guest_token_audit_test.py tests/integration_tests/embedded/test_view.py -q
    cd superset-frontend
    npm run test -- src/embedded/guestTokenDiagnostics.test.ts src/embedded/index.test.tsx --maxWorkers=2

Local validation:
- Isolated source smoke checks passed: 9 audit cases, 4 issuance-method cases, and TypeScript byte-budget/privacy/message checks. Source extraction/stubs do **not** replace pytest, Jest, route authorization, or browser tests.
- Repository pytest blocked during conftest import by missing paramiko.
- Repository Jest blocked by missing cross-env (frontend dependencies absent).
- Pre-commit against branch files: formatting, mypy, ruff, oxlint, basic hooks, and feature-flag sync pass. Frontend custom rules/stylelint/type checking blocked by missing glob, postcss-styled-syntax, and tscw-config.
- Post-commit pylint hook blocked because pylint is not installed.
- Local Superset health endpoint unavailable. No staging/browser/real ALB reproduction or acceptance-boundary verification performed.

Manual verification:
1. Configure a positive GUEST_TOKEN_HEADER_MAX_BYTES and reload the iframe.
2. Mint tokens below, at, and above the diagnostic budget; verify unchanged successful mint payload/status and size-only audit/warnings.
3. Exercise successful embedding, oversized proxy-rejected auth (including HTML), unrelated auth errors, refresh after startup, and refresh while auth is pending.
4. Confirm config reaches embedded bootstrap and diagnostics contain no credentials/SQL. Validate actual proxy behavior separately; unit-test boundaries are not exact ALB acceptance boundaries.

### ADDITIONAL INFORMATION

**Activation is outstanding.** Default GUEST_TOKEN_HEADER_MAX_BYTES is None, not a universal ALB policy. Set a deployment-specific positive integer in superset_config.py. Accounting is UTF-8 bytes of header name, colon-space, encoded token, and CRLF (four framing bytes); warn only when strictly greater. Zero/negative values disable warnings. Example only: GUEST_TOKEN_HEADER_MAX_BYTES = 16 * 1024. Choose headroom for the full proxy path and verify the deployment.

Preset uses the separate preset-io/superset-shell config layer: superset_config.py imports preset/config.py, which loads deployment preset_config overrides. A separate shell/deployment configuration change must activate this setting, followed by deployment and iframe reload. No other workspace/repository was modified; no Preset deployment activation is claimed.

[AWS documents a non-adjustable 16 K single-header limit](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html). This PR neither raises it nor changes token transport/storage. Entitlements-table substitutions must preserve row restrictions and be tested for equivalent access/performance.

The supplied local workflow-context file was unavailable; repository AGENTS.md, SECURITY.md, and the PR template were read. Target is preset-io/superset:master, not upstream Apache. No private customer evidence is included.

- [x] Has associated issue: SC-113432 (not marked resolved)
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration
- [x] Introduces new feature or API: opt-in diagnostics configuration
- [ ] Removes existing feature or API


### Docs CI follow-up

A separate docs-only commit fixes 12 pre-existing bare relative links in number-formatting.mdx and extensions/overview.md by adding the actual target .md/.mdx extensions. All targets were verified and the dynamic-currency-formatting anchor is preserved; no linter changes or exclusions. Base master c03f3441bd565b9fd5f082d0b875c467eeae441c independently reproduces the same 12 failures, so the diagnostics change did not introduce them. These fixes are included here at the user's explicit request to unblock this PR.

After the fix, yarn lint:docs-links reports: “✓ lint-docs-links: no broken internal links found”. Pre-commit on the two staged docs files and git diff --check pass. Full Docs CI rebuild is pending; this follow-up does not change diagnostics activation or transport limitations.


### Full Docs CI type-resolution follow-up

The reported 52 TypeScript errors are pre-existing: base c03f3441bd565b9fd5f082d0b875c467eeae441c and PR 082b020784 produce identical error lines after full generation, using the same installed dependency tree. The affected source, generator, compiler config, package manifest, and original lockfile are unchanged between those refs.

Root causes and focused fixes:
- The wildcard TypeScript paths mapping to node_modules bypassed normal package/@types fallback and resolved React imports to react/index.js. Removing only that fallback restores React declarations, including FC props inference for DatabaseIndex and inherited signatures for Card and GitHubButton. No component casts, generated-data casts, or type-check suppression.
- Normal package resolution exposes duplicate webpack types: Docusaurus resolved 5.109.2 while the docs plugin resolved 5.110.1. Deduplicate only webpack to the already-locked 5.110.1, satisfying all existing ranges. Yarn prunes the duplicate and its now-unused dependencies. No package.json version changes or broad upgrades.
- Full API generation also recreated 301 bare links in tag pages. Fix the generator to emit the actual .api.mdx target extension. Do not commit generated API/component/database churn or add linter exclusions.

Local environment matches CI: Node v24.16.0, Yarn 1.22.22, TypeScript 7.0.2; React 18.3.1, @types/react 19.2.17, antd 6.6.2, react-github-btn 1.4.0. Clean initial yarn install --check-cache completed; the deduplicated lockfile also passes yarn install --check-cache --frozen-lockfile. No React dependency change was needed.

Commits: a1a500f9c4 (resolution and webpack deduplication), 8c32ee29d9 (generated API links). Local yarn typecheck (301 endpoints, 37 tag pages, 3 generators), yarn lint:docs-links before/after generation and build, yarn build (static output generated, exit 0), targeted oxfmt/oxlint, staged-file pre-commit, and git diff --check all pass. Generated output was discarded rather than committed. New Docs CI is pending; its final result will be recorded here. Diagnostics deployment activation remains outstanding; SC-113432's transport limit is not fixed by these docs repairs.
